### PR TITLE
Improve AR prototype docs and server

### DIFF
--- a/AFramePrototype/README.md
+++ b/AFramePrototype/README.md
@@ -1,0 +1,23 @@
+# A-Frame Mobile AR Studio Prototype
+
+This directory contains a simple A-Frame example that connects to the `ARServerExample.py` server.
+
+## Usage
+
+1. Install the server dependencies:
+
+   ```bash
+   pip install -r ../ARStudioPrototype/requirements.txt
+   ```
+
+2. Start `ARStudioPrototype/ARServerExample.py`:
+
+   ```bash
+   python3 ARStudioPrototype/ARServerExample.py
+   ```
+
+3. Open `index.html` from this folder in a mobile browser (or desktop for testing). The page will periodically fetch tracking data from `http://localhost:5000/tracking` and apply it to a box entity.
+
+4. Modify the server to stream real AR tracking data from ARKit or ARCore for a full experience.
+
+This example demonstrates how A-Frame can be used as a lightweight web-based AR viewer that integrates with the Python server used for the Roblox plugin.

--- a/AFramePrototype/index.html
+++ b/AFramePrototype/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>A-Frame Mobile AR Studio Example</title>
+    <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
+  </head>
+  <body>
+    <a-scene embedded>
+      <a-box id="ar-box" position="0 1.5 -3" rotation="0 45 0" color="#4CC3D9"></a-box>
+      <a-sky color="#ECECEC"></a-sky>
+    </a-scene>
+    <script>
+      const box = document.getElementById('ar-box');
+      const url = 'http://localhost:5000/tracking';
+
+      async function fetchTracking() {
+        try {
+          const res = await fetch(url);
+          const data = await res.json();
+          const p = data.position;
+          const r = data.rotation;
+          box.setAttribute('position', `${p.x} ${p.y} ${p.z}`);
+          box.setAttribute('rotation', `${r.x} ${r.y} ${r.z}`);
+        } catch (e) {
+          console.warn('Failed to fetch tracking data:', e);
+        }
+      }
+
+      setInterval(fetchTracking, 100);
+    </script>
+  </body>
+</html>

--- a/ARStudioPrototype/ARServerExample.py
+++ b/ARStudioPrototype/ARServerExample.py
@@ -1,0 +1,19 @@
+"""Simple AR server example.
+This script simulates AR tracking data for testing the Roblox plugin.
+"""
+from flask import Flask, jsonify
+from flask_cors import CORS
+
+app = Flask(__name__)
+CORS(app)
+
+@app.route('/tracking')
+def tracking():
+    data = {
+        "position": {"x": 0, "y": 5, "z": 0},
+        "rotation": {"x": 0, "y": 0, "z": 0},
+    }
+    return jsonify(data)
+
+if __name__ == '__main__':
+    app.run(port=5000)

--- a/ARStudioPrototype/Plugin.lua
+++ b/ARStudioPrototype/Plugin.lua
@@ -1,0 +1,29 @@
+-- Plugin.lua: Connects to local AR server and updates Roblox objects
+local HttpService = game:GetService("HttpService")
+local RunService = game:GetService("RunService")
+
+local ARServerUrl = "http://localhost:5000/tracking" -- Example endpoint
+
+local function fetchTrackingData()
+    local success, result = pcall(function()
+        return HttpService:GetAsync(ARServerUrl)
+    end)
+    if success then
+        return HttpService:JSONDecode(result)
+    else
+        warn("Failed to fetch AR data: " .. result)
+        return nil
+    end
+end
+
+local trackedPart = Instance.new("Part")
+trackedPart.Name = "ARObject"
+trackedPart.Parent = workspace
+
+RunService.RenderStepped:Connect(function()
+    local data = fetchTrackingData()
+    if data then
+        trackedPart.CFrame = CFrame.new(data.position.x, data.position.y, data.position.z) *
+            CFrame.fromEulerAnglesXYZ(math.rad(data.rotation.x), math.rad(data.rotation.y), math.rad(data.rotation.z))
+    end
+end)

--- a/ARStudioPrototype/README.md
+++ b/ARStudioPrototype/README.md
@@ -1,0 +1,57 @@
+# Roblox AR Studio Prototype
+
+This prototype demonstrates the basic approach for integrating augmented reality (AR) features with Roblox. Roblox Studio does not natively support AR, so we bridge external AR frameworks (e.g., ARKit/ARCore) with Roblox via a local server and a plugin.
+
+First install the Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Components
+
+1. **External AR Server**: Runs on the developer's machine or mobile device. It captures camera data and AR tracking information and exposes it over a local network API.
+2. **Roblox Plugin (Lua)**: Connects to the external server, receives AR data, and updates Roblox objects accordingly.
+
+The example below shows a simplified Lua plugin that requests transformation data from the AR server.
+
+```lua
+-- Plugin.lua: Connects to local AR server and updates Roblox objects
+local HttpService = game:GetService("HttpService")
+local RunService = game:GetService("RunService")
+local ARServerUrl = "http://localhost:5000/tracking" -- Example endpoint
+
+-- Function to fetch AR tracking data from the server
+local function fetchTrackingData()
+    local success, result = pcall(function()
+        return HttpService:GetAsync(ARServerUrl)
+    end)
+    if success then
+        return HttpService:JSONDecode(result)
+    else
+        warn("Failed to fetch AR data: " .. result)
+        return nil
+    end
+end
+
+-- Update loop: apply AR transformations to a part
+local trackedPart = Instance.new("Part")
+trackedPart.Name = "ARObject"
+trackedPart.Parent = workspace
+
+RunService.RenderStepped:Connect(function()
+    local data = fetchTrackingData()
+    if data then
+        trackedPart.CFrame = CFrame.new(data.position.x, data.position.y, data.position.z) *
+            CFrame.fromEulerAnglesXYZ(math.rad(data.rotation.x), math.rad(data.rotation.y), math.rad(data.rotation.z))
+    end
+end)
+```
+
+## Usage Steps
+
+1. Create or reuse an ARKit/ARCore app that streams tracking data as JSON over HTTP. The server should include fields for `position` and `rotation`.
+2. Install this plugin in Roblox Studio and update `ARServerUrl` to match your local server's address.
+3. Run the server and then start play testing in Roblox Studio. The script will update `ARObject` to follow the AR device's pose.
+
+This is a minimal starting point. A real implementation would need networking security, latency handling, and more comprehensive data parsing.

--- a/ARStudioPrototype/requirements.txt
+++ b/ARStudioPrototype/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+Flask-Cors

--- a/README.md
+++ b/README.md
@@ -1,16 +1,13 @@
-## Hi there 👋
+# Welcome
 
-<!--
-**Heraw187/Heraw187** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
+This repository contains experiments and prototypes.
 
-Here are some ideas to get you started:
+To run the AR server used by both examples:
 
-- 🔭 I’m currently working on ...
-- 🌱 I’m currently learning ...
-- 👯 I’m looking to collaborate on ...
-- 🤔 I’m looking for help with ...
-- 💬 Ask me about ...
-- 📫 How to reach me: ...
-- 😄 Pronouns: ...
-- ⚡ Fun fact: ...
--->
+```bash
+pip install -r ARStudioPrototype/requirements.txt
+python3 ARStudioPrototype/ARServerExample.py
+```
+
+- `ARStudioPrototype/` — Python server and Roblox plugin example.
+- `AFramePrototype/` — basic A-Frame page that consumes the same AR data for mobile testing.


### PR DESCRIPTION
## Summary
- enable CORS in `ARServerExample.py` and remove unused import
- describe dependency install steps in AR prototype READMEs
- add `requirements.txt`
- document how to run the server in the main README

## Testing
- `python3 -m py_compile ARStudioPrototype/ARServerExample.py`
- `luac -p ARStudioPrototype/Plugin.lua`


------
https://chatgpt.com/codex/tasks/task_e_684bf75052b0832ab4aef88ef2d3debc