### PR TITLE
Add dynamic AR tracking server and docs

### DIFF
--- a/ARStudioPrototype/ARServerExample.py
+++ b/ARStudioPrototype/ARServerExample.py
@@ -1,18 +1,38 @@
 """Simple AR server example.
-This script simulates AR tracking data for testing the Roblox plugin.
+
+This script accepts AR tracking data via HTTP and serves the latest
+reading to clients (e.g., the Roblox plugin).
+
+POST JSON to ``/tracking`` with the fields ``position`` and ``rotation``
+to update the stored data. ``GET /tracking`` returns the most recent
+reading. This allows a mobile AR app to stream tracking data that the
+Roblox plugin can consume.
 """
-import json
-from flask import Flask, jsonify
+
+from flask import Flask, jsonify, request
 
 app = Flask(__name__)
 
-@app.route('/tracking')
-def tracking():
-    data = {
-        "position": {"x": 0, "y": 5, "z": 0},
-        "rotation": {"x": 0, "y": 0, "z": 0},
-    }
-    return jsonify(data)
+# In-memory store for the most recent tracking data
+latest_data = {
+    "position": {"x": 0, "y": 0, "z": 0},
+    "rotation": {"x": 0, "y": 0, "z": 0},
+}
 
-if __name__ == '__main__':
-    app.run(port=5000)
+
+@app.route("/tracking", methods=["GET", "POST"])
+def tracking():
+    """GET returns the latest data, POST updates it."""
+    global latest_data
+    if request.method == "POST":
+        data = request.get_json(silent=True) or {}
+        if "position" in data and "rotation" in data:
+            latest_data = data
+            return ("", 204)
+        return jsonify({"error": "Invalid data"}), 400
+    return jsonify(latest_data)
+
+
+if __name__ == "__main__":
+    # Listen on all interfaces so mobile devices on the same network can connect
+    app.run(host="0.0.0.0", port=5000)

--- a/ARStudioPrototype/README.md
+++ b/ARStudioPrototype/README.md
@@ -4,8 +4,8 @@ This prototype demonstrates the basic approach for integrating augmented reality
 
 ## Components
 
-1. **External AR Server**: Runs on the developer's machine or mobile device. It captures camera data and AR tracking information and exposes it over a local network API.
-2. **Roblox Plugin (Lua)**: Connects to the external server, receives AR data, and updates Roblox objects accordingly.
+1. **External AR Server** (`ARServerExample.py`): Runs on the developer's machine or a mobile device. It accepts tracking data over HTTP (``POST /tracking``) and serves the latest reading to clients (``GET /tracking``).
+2. **Roblox Plugin (Lua)**: Connects to the server, receives AR data, and updates Roblox objects accordingly.
 
 The example below shows a simplified Lua plugin that requests transformation data from the AR server.
 
@@ -44,8 +44,20 @@ end)
 
 ## Usage Steps
 
-1. Create or reuse an ARKit/ARCore app that streams tracking data as JSON over HTTP. The server should include fields for `position` and `rotation`.
-2. Install this plugin in Roblox Studio and update `ARServerUrl` to match your local server's address.
-3. Run the server and then start play testing in Roblox Studio. The script will update `ARObject` to follow the AR device's pose.
+1. Start the server:
+
+   ```bash
+   python ARServerExample.py
+   ```
+
+   It will listen on port 5000. A sample script (`send_test_data.py`) is provided to push dummy data:
+
+   ```bash
+   python send_test_data.py
+   ```
+
+   Real AR apps can ``POST`` JSON to ``/tracking`` with ``position`` and ``rotation`` fields.
+2. Install the plugin in Roblox Studio and update `ARServerUrl` if the server runs on a different machine or port.
+3. Run Roblox Studio. The script will update `ARObject` to follow the pose data served by the Python app.
 
 This is a minimal starting point. A real implementation would need networking security, latency handling, and more comprehensive data parsing.

--- a/ARStudioPrototype/send_test_data.py
+++ b/ARStudioPrototype/send_test_data.py
@@ -1,0 +1,24 @@
+"""Utility to send sample tracking data to the AR server.
+
+Run this script after starting ``ARServerExample.py`` to simulate an
+AR device pushing pose data. The server stores the latest payload and the
+Roblox plugin can then fetch it.
+"""
+
+import json
+import requests
+
+URL = "http://localhost:5000/tracking"
+
+payload = {
+    "position": {"x": 1, "y": 2, "z": 3},
+    "rotation": {"x": 10, "y": 20, "z": 30},
+}
+
+resp = requests.post(URL, json=payload)
+resp.raise_for_status()
+print("Sent payload:", json.dumps(payload))
+
+# Fetch it back to verify
+verify = requests.get(URL)
+print("Server returned:", verify.json())

--- a/NoCodeARStudio.md
+++ b/NoCodeARStudio.md
@@ -1,0 +1,31 @@
+# Building a No-Code AR Studio with Frsmey and WebAR
+
+This guide outlines a conceptual approach for assembling a simple AR authoring environment without writing code. The flow assumes you are using **Frsmey** (a drag-and-drop tool for layouts) together with a WebAR framework.
+
+## 1. Design the AR Scene in Frsmey
+
+1. Create a new project in Frsmey.
+2. Use its interface to place 3D models, images, and UI elements.
+3. Configure interactions or animations using built-in settings—no scripting required.
+
+## 2. Export to WebAR
+
+1. Frsmey lets you export your scene as HTML/CSS/JS files.
+2. Choose an export format compatible with WebAR platforms such as **AR.js** or **8th Wall**.
+3. Download the exported files to your computer.
+
+## 3. Host and Test
+You can use the sample page in `WebARExample/` as a template for hosting or quick testing.
+
+1. Deploy the exported package to a web server (GitHub Pages or similar).
+2. Open the link on a mobile device with camera access.
+3. Your scene should load in the browser and display the AR content.
+
+## 4. Optional Integration with Roblox
+
+If you want to connect WebAR output back to Roblox (as in the prototype under `ARStudioPrototype/`), you can:
+
+1. Run the example AR server (`ARServerExample.py`). It exposes a ``/tracking`` endpoint where a mobile app can ``POST`` pose data and the Roblox plugin can ``GET`` the latest reading. A helper script (`send_test_data.py`) is available for quick testing.
+2. Adjust the Roblox plugin to fetch data from your WebAR app if it exposes tracking information.
+
+This approach keeps the workflow entirely no-code while leveraging Frsmey for layout and WebAR for deployment.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Welcome
 
-This repository contains experiments and prototypes. See `ARStudioPrototype/` for a simple example of integrating augmented reality with Roblox Studio.
+This repository contains experiments and prototypes. See `ARStudioPrototype/` for a simple example of integrating augmented reality with Roblox Studio. The Python utilities require `flask` and `requests` (install via `pip install -r requirements.txt`).
+
+For guidance on building a no-code AR studio with Frsmey and WebAR, see `NoCodeARStudio.md`.
+
+For a minimal WebAR page to try out, see `WebARExample/`.

--- a/WebARExample/README.md
+++ b/WebARExample/README.md
@@ -1,0 +1,9 @@
+# WebAR Example
+
+This folder contains a minimal AR.js page that you can use as a starting point for your no-code workflow.
+
+1. Open `index.html` to view the example. It uses A-Frame with AR.js to display a red cube on the "hiro" marker.
+2. Replace the contents of the `<a-scene>` element with the markup exported from Frsmey to integrate your own design.
+3. Host the page on a web server (for local testing you can run `python3 -m http.server` inside this folder) and open the URL on a mobile device with camera access.
+
+This demonstrates how a WebAR page can work with content produced in a no-code tool.

--- a/WebARExample/index.html
+++ b/WebARExample/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>WebAR Example</title>
+    <!-- A-Frame and AR.js libraries from CDN -->
+    <script src="https://aframe.io/releases/1.4.1/aframe.min.js"></script>
+    <script src="https://raw.githack.com/AR-js-org/AR.js/3.3.2/aframe/build/aframe-ar.js"></script>
+  </head>
+  <body style="margin: 0; overflow: hidden;">
+    <!-- Replace this scene with your export from Frsmey if desired -->
+    <a-scene embedded arjs>
+      <a-box position="0 0.5 0" color="red"></a-box>
+      <a-marker-camera preset="hiro"></a-marker-camera>
+    </a-scene>
+  </body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+requests


### PR DESCRIPTION
## Summary
- Expand ARServerExample into a stateful Flask API that accepts POSTed tracking data and serves it to clients
- Provide `send_test_data.py` and updated guides for testing and integration with Roblox
- Document Python dependencies with a requirements file

## Testing
- `pip install flask requests`
- `python ARStudioPrototype/send_test_data.py`


------
https://chatgpt.com/codex/tasks/task_e_684bfbda8390832ab59b45698f494d40