### PR TITLE
Add academic capability brief for AR prototype

### DIFF
--- a/ARStudioPrototype/ACADEMIC_CAPABILITIES.md
+++ b/ARStudioPrototype/ACADEMIC_CAPABILITIES.md
@@ -1,0 +1,44 @@
+# Academic Capability Brief: Roblox AR Studio Prototype
+
+## Purpose
+This document summarizes, in an academic and practitioner-friendly style, the capabilities unlocked by the Roblox AR Studio Prototype contained in this repository. It explains what you can build, observe, and evaluate when coupling Roblox Studio with an external AR framework via the provided server and plugin examples.
+
+## System Context
+- **Architecture**: An external AR server (e.g., ARKit/ARCore bridge) streams pose data over HTTP, while a Roblox Studio plugin consumes that data to drive in-world transforms.
+- **Data Flow**: Device sensors → AR framework → Local HTTP endpoint → Roblox Lua plugin → Workspace objects.
+- **Objective**: Demonstrate a reproducible loop for translating real-world spatial signals into Roblox scenes for research, prototyping, or teaching.
+
+## Core Capabilities
+1. **Real-Time Pose Injection**
+   - Consume `position` and `rotation` vectors from a local AR endpoint (see `ARServerExample.py`).
+   - Update in-world objects each render step to mirror device pose, enabling spatial anchoring experiments.
+2. **External Sensor Integration**
+   - Swap the mock server for a production ARKit/ARCore feed to test end-to-end AR telemetry in Roblox without native engine support.
+3. **Networked Experimentation Loop**
+   - Evaluate latency, jitter, and update frequency effects on perceived alignment between the physical device and virtual proxy objects.
+4. **Plugin-Level Extensibility**
+   - Extend the Lua plugin with filtering, interpolation, or multi-object mapping to study stability and user comfort.
+5. **Cross-Disciplinary Prototyping**
+   - Combine computer vision/SLAM outputs with Roblox gameplay logic, enabling studies in mixed-reality UI/UX, collaborative AR scenes, or educational simulations.
+
+## Research and Teaching Uses
+- **Human Factors**: Measure user perception when virtual objects follow physical movements; test comfort thresholds and update rates.
+- **Systems Evaluation**: Prototype network strategies (e.g., buffering, smoothing) and assess their impact on spatial coherence.
+- **XR Interaction Design**: Trial gesture-based triggers or contextual overlays by extending the server payload beyond pose data.
+- **Education**: Illustrate AR/VR pipelines in coursework by showing how sensor data becomes actionable in a game engine without native AR hooks.
+
+## How to Exercise the Capabilities
+1. Start the Flask-based mock AR server (`python ARServerExample.py`) to emit sample pose data on `http://localhost:5000/tracking`.
+2. Install the Lua plugin in Roblox Studio, pointing `ARServerUrl` to your server endpoint.
+3. Run play mode to observe the `ARObject` part updating in real time; instrument the script to log latency or apply smoothing filters.
+4. Replace the mock server with a real ARKit/ARCore feed and repeat measurements to benchmark realism and stability.
+
+## Evaluation Notes
+- **Metrics**: Track end-to-end latency, positional drift, rotation jitter, and frame-to-frame stability.
+- **Variations**: Experiment with HTTP polling frequency, data smoothing (e.g., exponential moving averages), or socket-based transports for reduced latency.
+- **Safety & Security**: When moving beyond localhost, harden endpoints (auth, rate limits) and sanitize inputs before applying transforms.
+
+## Extending the Prototype
+- Integrate additional sensor channels (depth maps, plane detection) into the server response and map them to Roblox primitives.
+- Add collaborative sync so multiple clients share AR anchors, enabling co-located or remote AR experiences.
+- Embed analytics to capture user behavior and system performance for academic reporting.


### PR DESCRIPTION
## Summary
- add an academic-style capabilities brief describing what the Roblox AR Studio prototype enables
- outline research/teaching use cases, evaluation guidance, and extension ideas for the AR server and plugin

## Testing
- Not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fc4b81ff4832aabec4d3b2c4bbdd5)